### PR TITLE
Updating Code Climate definitions

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -18,3 +18,4 @@ ratings:
 exclude_paths:
 - node_modules/
 - app/bower_components/
+- app/styles/


### PR DESCRIPTION
Code Climate is complaining about our demo CSS file.
The issue in here is that this CSS file is actually from Bootstrap
project and being generated from a Sass file.

This commit just ignores it.