### PR TITLE
Targets sandbox instance of Equipment Facade API

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 module.exports = {
   PORT: process.env.PORT || '8000',
   FUSE_TRACKERS_URL: process.env.FUSE_TRACKERS_URL || 'https://agco-fuse-trackers-sandbox.herokuapp.com',
-  FUSE_EQUIPMENT_API_URL: process.env.EQUIPMENT_API_URL || 'https://fuse-equipment-api.herokuapp.com',
+  FUSE_EQUIPMENT_API_URL: process.env.EQUIPMENT_API_URL || 'https://fuse-equipment-api-sandbox.herokuapp.com',
   OPENAM_USERNAME: process.env.OPENAM_USERNAME,
   OPENAM_PASSWORD: process.env.OPENAM_PASSWORD,
   OPENAM_URL: process.env.OPENAM_URL || 'https://aaat.agcocorp.com/auth/oauth2/access_token',


### PR DESCRIPTION
Our example always dealt with sandbox environment. Recently we updated
`fuse-equipment-api.herokuapp.com/` to point to
`agco-fuse-trackers.herokuapp.com`. This means that now, the example is
pointing to production environment.

This change made the example stop working for sandbox users which do not
have production access. In order to fix this problem, this commit
switchs back to sandbox environment.