### PR TITLE
Fixing dependencies vulnerabilities

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,1 +1,10 @@
-version: v1
+version: v1.5.0
+ignore:
+  'npm:minimatch:20160620':
+    - snyk > recursive-readdir > minimatch:
+        reason: No patch available
+        expires: '2016-07-21T17:10:20.179Z'
+    - recursive-readdir > minimatch:
+        reason: No patch available
+        expires: '2016-07-21T17:10:20.179Z'
+patch: {}

--- a/package.json
+++ b/package.json
@@ -17,17 +17,20 @@
   ],
   "author": "AGCO",
   "dependencies": {
+    "accepts": "^1.3.3",
     "bower": "^1.7.9",
-    "express": "^4.13.4",
+    "eslint": "^2.8.0",
+    "express": "^4.14.0",
     "express-handlebars": "^3.0.0",
+    "minimatch": "^3.0.2",
     "request-promise": "^3.0.0"
   },
   "devDependencies": {
-    "eslint": "^2.8.0",
+    "eslint": "^2.13.1",
     "eslint-config-agco": "0.0.3",
     "eslint-config-angular": "^0.5.0",
     "eslint-plugin-angular": "^1.0.0",
     "eslint-plugin-standard": "^1.3.2",
-    "snyk": "^1.14.1"
+    "snyk": "^1.14.3"
   }
 }


### PR DESCRIPTION
This morning we noticed that several npm packages are broken due to a
high severity vulnerability on minimatch package.

This problem started today. We updated our dependencies to their latest
version, but most of them haven't updated.

We set it to ignore this problem for the next 30 days. That might be
enough time to get updates on most of these packages.